### PR TITLE
feat: implement SOL transfer functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+scilla.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +266,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +289,17 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -314,6 +347,12 @@ checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -859,6 +898,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1565,6 +1628,8 @@ name = "scilla"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
+ "comfy-table",
  "console",
  "indicatif",
  "inquire",
@@ -3060,10 +3125,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ solana-pubkey = "4.0.0"
 solana-transaction = "3.0.2"
 solana-message = "3.0.1"
 solana-system-interface = { version = "2.0.0", features = ["bincode"] }
+chrono = "0.4"
+comfy-table = "7.1"

--- a/scilla.example.toml
+++ b/scilla.example.toml
@@ -1,2 +1,3 @@
 rpc-url = "https://api.mainnet-beta.solana.com"
 keypair-path = "~/.config/solana/id.json"
+commitment-level = "confirmed"

--- a/src/commands/cluster.rs
+++ b/src/commands/cluster.rs
@@ -1,3 +1,13 @@
+use {
+    crate::{
+        commands::CommandExec, constants::LAMPORTS_PER_SOL, context::ScillaContext,
+        error::ScillaResult, ui::show_spinner,
+    },
+    comfy_table::{Cell, Table, presets::UTF8_FULL},
+    console::style,
+    std::ops::Div,
+};
+
 /// Commands related to cluster operations
 #[derive(Debug, Clone)]
 pub enum ClusterCommand {
@@ -10,4 +20,315 @@ pub enum ClusterCommand {
     Inflation,
     ClusterVersion,
     GoBack,
+}
+
+impl ClusterCommand {
+    pub fn description(&self) -> &'static str {
+        match self {
+            ClusterCommand::Epoch => "Get Epoch Info",
+            ClusterCommand::Slot => "Get Current Slot",
+            ClusterCommand::BlockHeight => "Get Block Height",
+            ClusterCommand::BlockTime => "Get Block Time",
+            ClusterCommand::Validators => "Get Validators",
+            ClusterCommand::Supply => "Get Supply Info",
+            ClusterCommand::Inflation => "Get Inflation Info",
+            ClusterCommand::ClusterVersion => "Get Cluster Version",
+            ClusterCommand::GoBack => "Go back",
+        }
+    }
+}
+
+impl ClusterCommand {
+    pub async fn process_command(&self, ctx: &ScillaContext) -> ScillaResult<()> {
+        match self {
+            ClusterCommand::Epoch => {
+                show_spinner(self.description(), fetch_epoch_info(ctx)).await?;
+            }
+            ClusterCommand::Slot => {
+                show_spinner(self.description(), fetch_current_slot(ctx)).await?;
+            }
+            ClusterCommand::BlockHeight => {
+                show_spinner(self.description(), fetch_block_height(ctx)).await?;
+            }
+            ClusterCommand::BlockTime => {
+                show_spinner(self.description(), fetch_block_time(ctx)).await?;
+            }
+            ClusterCommand::Validators => {
+                show_spinner(self.description(), fetch_validators(ctx)).await?;
+            }
+            ClusterCommand::Supply => {
+                show_spinner(self.description(), fetch_supply_info(ctx)).await?;
+            }
+            ClusterCommand::Inflation => {
+                show_spinner(self.description(), fetch_inflation_info(ctx)).await?;
+            }
+            ClusterCommand::ClusterVersion => {
+                show_spinner(self.description(), fetch_cluster_version(ctx)).await?;
+            }
+            ClusterCommand::GoBack => {
+                return Ok(CommandExec::GoBack);
+            }
+        };
+
+        Ok(CommandExec::Process(()))
+    }
+}
+
+async fn fetch_epoch_info(ctx: &ScillaContext) -> anyhow::Result<()> {
+    let epoch_info = ctx.rpc().get_epoch_info().await?;
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Field").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Value").add_attribute(comfy_table::Attribute::Bold),
+        ])
+        .add_row(vec![
+            Cell::new("Epoch"),
+            Cell::new(format!("{}", epoch_info.epoch)),
+        ])
+        .add_row(vec![
+            Cell::new("Slot Index"),
+            Cell::new(format!("{}", epoch_info.slot_index)),
+        ])
+        .add_row(vec![
+            Cell::new("Slots in Epoch"),
+            Cell::new(format!("{}", epoch_info.slots_in_epoch)),
+        ])
+        .add_row(vec![
+            Cell::new("Absolute Slot"),
+            Cell::new(format!("{}", epoch_info.absolute_slot)),
+        ])
+        .add_row(vec![
+            Cell::new("Block Height"),
+            Cell::new(format!("{}", epoch_info.block_height)),
+        ])
+        .add_row(vec![
+            Cell::new("Transaction Count"),
+            Cell::new(format!("{}", epoch_info.transaction_count.unwrap_or(0))),
+        ]);
+
+    println!("\n{}", style("EPOCH INFORMATION").green().bold());
+    println!("{}", table);
+
+    Ok(())
+}
+
+async fn fetch_current_slot(ctx: &ScillaContext) -> anyhow::Result<()> {
+    let slot = ctx.rpc().get_slot().await?;
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Field").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Value").add_attribute(comfy_table::Attribute::Bold),
+        ])
+        .add_row(vec![
+            Cell::new("Current Slot"),
+            Cell::new(format!("{}", slot)),
+        ]);
+
+    println!("\n{}", style("CURRENT SLOT").green().bold());
+    println!("{}", table);
+
+    Ok(())
+}
+
+async fn fetch_block_height(ctx: &ScillaContext) -> anyhow::Result<()> {
+    let block_height = ctx.rpc().get_block_height().await?;
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Field").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Value").add_attribute(comfy_table::Attribute::Bold),
+        ])
+        .add_row(vec![
+            Cell::new("Block Height"),
+            Cell::new(format!("{}", block_height)),
+        ]);
+
+    println!("\n{}", style("BLOCK HEIGHT").green().bold());
+    println!("{}", table);
+
+    Ok(())
+}
+
+async fn fetch_block_time(ctx: &ScillaContext) -> anyhow::Result<()> {
+    let slot = ctx.rpc().get_slot().await?;
+    let block_time = ctx.rpc().get_block_time(slot).await?;
+
+    let datetime = chrono::DateTime::<chrono::Utc>::from_timestamp_secs(block_time)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+        .unwrap_or_else(|| "Invalid timestamp".to_string());
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Field").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Value").add_attribute(comfy_table::Attribute::Bold),
+        ])
+        .add_row(vec![Cell::new("Slot"), Cell::new(format!("{}", slot))])
+        .add_row(vec![
+            Cell::new("Unix Timestamp"),
+            Cell::new(format!("{}", block_time)),
+        ])
+        .add_row(vec![Cell::new("Date/Time"), Cell::new(datetime)]);
+
+    println!("\n{}", style("BLOCK TIME").green().bold());
+    println!("{}", table);
+
+    Ok(())
+}
+
+async fn fetch_validators(ctx: &ScillaContext) -> anyhow::Result<()> {
+    let validators = ctx.rpc().get_vote_accounts().await?;
+
+    // Summary table
+    let mut summary_table = Table::new();
+    summary_table
+        .load_preset(UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Field").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Value").add_attribute(comfy_table::Attribute::Bold),
+        ])
+        .add_row(vec![
+            Cell::new("Current Validators"),
+            Cell::new(format!("{}", validators.current.len())),
+        ])
+        .add_row(vec![
+            Cell::new("Delinquent Validators"),
+            Cell::new(format!("{}", validators.delinquent.len())),
+        ]);
+
+    println!("\n{}", style("VALIDATORS SUMMARY").green().bold());
+    println!("{}", summary_table);
+
+    // Validators detail table
+    if !validators.current.is_empty() {
+        let mut validators_table = Table::new();
+        validators_table.load_preset(UTF8_FULL).set_header(vec![
+            Cell::new("#").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Node Pubkey").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Vote Account").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Activated Stake (SOL)").add_attribute(comfy_table::Attribute::Bold),
+        ]);
+
+        for (idx, validator) in validators.current.iter().enumerate() {
+            let stake_sol = (validator.activated_stake as f64).div(LAMPORTS_PER_SOL as f64);
+            validators_table.add_row(vec![
+                Cell::new(format!("{}", idx + 1)),
+                Cell::new(validator.node_pubkey.clone()),
+                Cell::new(validator.vote_pubkey.clone()),
+                Cell::new(format!("{:.2}", stake_sol)),
+            ]);
+        }
+
+        println!("\n{}", style("TOP VALIDATORS").green().bold());
+        println!("{}", validators_table);
+    }
+
+    Ok(())
+}
+
+async fn fetch_supply_info(ctx: &ScillaContext) -> anyhow::Result<()> {
+    let supply = ctx.rpc().supply().await?;
+
+    let total_sol = (supply.value.total as f64).div(LAMPORTS_PER_SOL as f64);
+    let circulating_sol = (supply.value.circulating as f64).div(LAMPORTS_PER_SOL as f64);
+    let non_circulating_sol = (supply.value.non_circulating as f64).div(LAMPORTS_PER_SOL as f64);
+    let circulating_pct = (circulating_sol / total_sol) * 100.0;
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Field").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Value (SOL)").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Percentage").add_attribute(comfy_table::Attribute::Bold),
+        ])
+        .add_row(vec![
+            Cell::new("Total Supply"),
+            Cell::new(format!("{:.2}", total_sol)),
+            Cell::new("100.00%"),
+        ])
+        .add_row(vec![
+            Cell::new("Circulating"),
+            Cell::new(format!("{:.2}", circulating_sol)),
+            Cell::new(format!("{:.2}%", circulating_pct)),
+        ])
+        .add_row(vec![
+            Cell::new("Non-Circulating"),
+            Cell::new(format!("{:.2}", non_circulating_sol)),
+            Cell::new(format!("{:.2}%", 100.0 - circulating_pct)),
+        ]);
+
+    println!("\n{}", style("SUPPLY INFORMATION").green().bold());
+    println!("{}", table);
+
+    Ok(())
+}
+
+async fn fetch_inflation_info(ctx: &ScillaContext) -> anyhow::Result<()> {
+    let inflation = ctx.rpc().get_inflation_rate().await?;
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Field").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Value").add_attribute(comfy_table::Attribute::Bold),
+        ])
+        .add_row(vec![
+            Cell::new("Epoch"),
+            Cell::new(format!("{}", inflation.epoch)),
+        ])
+        .add_row(vec![
+            Cell::new("Total Inflation Rate"),
+            Cell::new(format!("{:.4}%", inflation.total * 100.0)),
+        ])
+        .add_row(vec![
+            Cell::new("Validator Inflation"),
+            Cell::new(format!("{:.4}%", inflation.validator * 100.0)),
+        ])
+        .add_row(vec![
+            Cell::new("Foundation Inflation"),
+            Cell::new(format!("{:.4}%", inflation.foundation * 100.0)),
+        ]);
+
+    println!("\n{}", style("INFLATION INFORMATION").green().bold());
+    println!("{}", table);
+
+    Ok(())
+}
+
+async fn fetch_cluster_version(ctx: &ScillaContext) -> anyhow::Result<()> {
+    let version = ctx.rpc().get_version().await?;
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Field").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Value").add_attribute(comfy_table::Attribute::Bold),
+        ])
+        .add_row(vec![
+            Cell::new("Solana Core"),
+            Cell::new(version.solana_core.clone()),
+        ]);
+
+    if let Some(feature_set) = version.feature_set {
+        table.add_row(vec![
+            Cell::new("Feature Set"),
+            Cell::new(format!("{}", feature_set)),
+        ]);
+    }
+
+    println!("\n{}", style("CLUSTER VERSION").green().bold());
+    println!("{}", table);
+
+    Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -43,7 +43,7 @@ pub enum Command {
 impl Command {
     pub async fn process_command(&self, ctx: &ScillaContext) -> ScillaResult<()> {
         match self {
-            Command::Cluster(_cluster_command) => todo!(),
+            Command::Cluster(cluster_command) => cluster_command.process_command(ctx).await,
             Command::Stake(stake_command) => stake_command.process_command(ctx).await,
             Command::Account(account_command) => account_command.process_command(ctx).await,
             Command::Vote(_vote_command) => todo!(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,9 @@
 use {
-    crate::error::ScillaError,
+    crate::{constants::SCILLA_CONFIG_RELATIVE_PATH, error::ScillaError},
     serde::{Deserialize, Serialize},
     solana_commitment_config::CommitmentLevel,
     std::{env::home_dir, fs, path::PathBuf},
 };
-
-pub const SCILLA_CONFIG_RELATIVE_PATH: &str = ".config/scilla.toml";
 
 pub fn scilla_config_path() -> PathBuf {
     let mut path = home_dir().expect("Error getting home path");
@@ -13,11 +11,30 @@ pub fn scilla_config_path() -> PathBuf {
     path
 }
 
+pub fn expand_tilde(path: &str) -> PathBuf {
+    // On TOMLs, ~ is not expanded, so do it manually
+
+    if let Some(stripped) = path.strip_prefix("~/")
+        && let Some(home) = home_dir() {
+            return home.join(stripped);
+        }
+    PathBuf::from(path)
+}
+
+fn deserialize_path_with_tilde<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    Ok(expand_tilde(&s))
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct ScillaConfig {
     pub rpc_url: String,
     pub commitment_level: CommitmentLevel,
+    #[serde(deserialize_with = "deserialize_path_with_tilde")]
     pub keypair_path: PathBuf,
     #[serde(default)]
     pub cluster: Option<String>,
@@ -26,7 +43,7 @@ pub struct ScillaConfig {
 impl ScillaConfig {
     pub fn load() -> Result<ScillaConfig, ScillaError> {
         let scilla_config_path = scilla_config_path();
-        println!("{:?}", scilla_config_path);
+        println!("Using Scilla config path : {scilla_config_path:?}");
         if !scilla_config_path.exists() {
             return Err(ScillaError::ConfigPathDoesntExists);
         }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,1 +1,2 @@
 pub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
+pub const SCILLA_CONFIG_RELATIVE_PATH: &str = ".config/scilla.toml";

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -46,6 +46,7 @@ fn prompt_cluster() -> anyhow::Result<ClusterCommand> {
             "Cluster Version",
             "Supply Info",
             "Inflation",
+            "Go Back",
         ],
     )
     .prompt()?;
@@ -59,6 +60,7 @@ fn prompt_cluster() -> anyhow::Result<ClusterCommand> {
         "Cluster Version" => ClusterCommand::ClusterVersion,
         "Supply Info" => ClusterCommand::Supply,
         "Inflation" => ClusterCommand::Inflation,
+        "Go Back" => ClusterCommand::GoBack,
         _ => unreachable!(),
     })
 }


### PR DESCRIPTION
scilla CLI had a `Transfer SOL` command in the account menu, but it was not implemented. users couldn't transfer SOL through the CLI and had to rely on external tools or manually build transactions 

cc @Nagaprasadvr  @sonicfromnewyoke 