### PR TITLE
Fixed confirm txn issue, The menu displays "Check Transaction Confirmation" but the match arm expects "Confirm Transaction"

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -117,7 +117,7 @@ fn prompt_account() -> anyhow::Result<AccountCommand> {
         "Balance" => AccountCommand::Balance,
         "Transfer" => AccountCommand::Transfer,
         "Airdrop" => AccountCommand::Airdrop,
-        "Confirm Transaction" => AccountCommand::CheckTransactionConfirmation,
+        "Check Transaction Confirmation" => AccountCommand::CheckTransactionConfirmation,
         "Largest Accounts" => AccountCommand::LargestAccounts,
         "Nonce Account" => AccountCommand::NonceAccount,
         "Go Back" => AccountCommand::GoBack,


### PR DESCRIPTION
<img width="1264" height="320" alt="image" src="https://github.com/user-attachments/assets/87ba903b-06d9-4965-90b2-314f92206ab5" />
