### PR TITLE
feat: implement config show/generate/edit commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1376,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libredox"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1584,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -1831,6 +1868,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2066,7 @@ dependencies = [
  "chrono",
  "comfy-table",
  "console",
+ "dirs",
  "indicatif",
  "inquire",
  "serde",
@@ -2032,6 +2081,7 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-signature",
  "solana-stake-interface",
+ "solana-system-interface",
  "solana-transaction",
  "solana-vote-program",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,7 @@ solana-native-token = "3.0.0"
 solana-message = "3.0.1"
 solana-stake-interface = "2.0.2"
 solana-transaction = "3.0.2"
+solana-system-interface = { version = "2.0", features = ["bincode"] }
+dirs = "6.0"
 
 

--- a/src/commands/account.rs
+++ b/src/commands/account.rs
@@ -8,7 +8,7 @@ use {
         ui::{print_error, show_spinner},
     },
     anyhow::bail,
-    comfy_table::{Cell, Table, presets::UTF8_FULL},
+    comfy_table::{presets::UTF8_FULL, Cell, Table},
     console::style,
     inquire::Select,
     solana_nonce::versions::Versions,
@@ -58,7 +58,7 @@ impl fmt::Display for AccountCommand {
             AccountCommand::NonceAccount => "Nonce Account",
             AccountCommand::GoBack => "Go Back",
         };
-        write!(f, "{}", command)
+        write!(f, "{command}")
     }
 }
 
@@ -110,7 +110,7 @@ async fn request_sol_airdrop(ctx: &ScillaContext) -> anyhow::Result<()> {
             );
         }
         Err(err) => {
-            print_error(format!("Airdrop failed: {}", err));
+            print_error(format!("Airdrop failed: {err}"));
         }
     }
 
@@ -197,7 +197,7 @@ async fn confirm_transaction(ctx: &ScillaContext, signature: &Signature) -> anyh
         ]);
 
     println!("\n{}", style("TRANSACTION CONFIRMATION").green().bold());
-    println!("{}", table);
+    println!("{table}");
 
     Ok(())
 }
@@ -236,12 +236,12 @@ async fn fetch_largest_accounts(ctx: &ScillaContext) -> anyhow::Result<()> {
         table.add_row(vec![
             Cell::new(format!("{}", idx + 1)),
             Cell::new(account.address.clone()),
-            Cell::new(format!("{:.2}", balance_sol)),
+            Cell::new(format!("{balance_sol:.2}")),
         ]);
     }
 
     println!("\n{}", style("LARGEST ACCOUNTS").green().bold());
-    println!("{}", table);
+    println!("{table}");
 
     Ok(())
 }
@@ -250,7 +250,7 @@ async fn fetch_nonce_account(ctx: &ScillaContext, pubkey: &Pubkey) -> anyhow::Re
     let account = ctx.rpc().get_account(pubkey).await?;
 
     let versions = bincode::deserialize::<Versions>(&account.data)
-        .map_err(|e| anyhow::anyhow!("Failed to deserialize nonce account data: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to deserialize nonce account data: {e}"))?;
 
     let solana_nonce::state::State::Initialized(data) = versions.state() else {
         bail!("This account is not an initialized nonce account");
@@ -295,7 +295,7 @@ async fn fetch_nonce_account(ctx: &ScillaContext, pubkey: &Pubkey) -> anyhow::Re
         ]);
 
     println!("\n{}", style("NONCE ACCOUNT INFO").green().bold());
-    println!("{}", table);
+    println!("{table}");
 
     Ok(())
 }

--- a/src/commands/cluster.rs
+++ b/src/commands/cluster.rs
@@ -3,7 +3,7 @@ use {
         commands::CommandExec, constants::LAMPORTS_PER_SOL, context::ScillaContext,
         error::ScillaResult, ui::show_spinner,
     },
-    comfy_table::{Cell, Table, presets::UTF8_FULL},
+    comfy_table::{presets::UTF8_FULL, Cell, Table},
     console::style,
     std::{fmt, ops::Div},
 };
@@ -51,7 +51,7 @@ impl fmt::Display for ClusterCommand {
             ClusterCommand::Inflation => "Inflation",
             ClusterCommand::GoBack => "Go Back",
         };
-        write!(f, "{}", command)
+        write!(f, "{command}")
     }
 }
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,8 +1,12 @@
 use {
-    crate::{ScillaContext, ScillaResult, commands::CommandExec},
+    crate::{commands::CommandExec, context::ScillaContext, error::ScillaResult},
+    comfy_table::{presets::UTF8_FULL, Cell, Table},
+    console::style,
+    inquire::{Select, Text},
     std::fmt,
 };
-/// Commands related to configuration like RPC_URL , KEYAPAIR_PATH etc
+
+/// Commands related to configuration like RPC_URL, KEYPAIR_PATH etc
 #[derive(Debug, Clone)]
 pub enum ConfigCommand {
     Show,
@@ -30,17 +34,107 @@ impl fmt::Display for ConfigCommand {
             ConfigCommand::Edit => "Edit ScillaConfig",
             ConfigCommand::GoBack => "Go Back",
         };
-        write!(f, "{}", command)
+        write!(f, "{command}")
     }
 }
 
 impl ConfigCommand {
     pub async fn process_command(&self, _ctx: &ScillaContext) -> ScillaResult<()> {
         match self {
-            ConfigCommand::Show => todo!(),
-            ConfigCommand::Generate => todo!(),
-            ConfigCommand::Edit => todo!(),
-            ConfigCommand::GoBack => Ok(CommandExec::GoBack),
+            ConfigCommand::Show => {
+                let config_path = dirs::config_dir()
+                    .ok_or_else(|| anyhow::anyhow!("Could not find config directory"))?
+                    .join("scilla.toml");
+
+                if !config_path.exists() {
+                    println!(
+                        "{}",
+                        style("No Scilla config found. Use 'Generate' to create one.").yellow()
+                    );
+                    return Ok(CommandExec::Process(()));
+                }
+
+                let content = std::fs::read_to_string(&config_path)?;
+                let config: toml::Value = toml::from_str(&content)?;
+
+                let mut table = Table::new();
+                table.load_preset(UTF8_FULL).set_header(vec![
+                    Cell::new("Setting").add_attribute(comfy_table::Attribute::Bold),
+                    Cell::new("Value").add_attribute(comfy_table::Attribute::Bold),
+                ]);
+
+                if let toml::Value::Table(map) = config {
+                    for (key, value) in map {
+                        table.add_row(vec![
+                            Cell::new(&key),
+                            Cell::new(value.to_string().trim_matches('"')),
+                        ]);
+                    }
+                }
+
+                println!("\n{}", style("SCILLA CONFIGURATION").green().bold());
+                println!("{table}");
+            }
+            ConfigCommand::Generate => {
+                let rpc_preset = Select::new(
+                    "Select RPC endpoint:",
+                    vec!["Devnet", "Testnet", "Mainnet-Beta", "Custom"],
+                )
+                .prompt()?;
+
+                let rpc_url = match rpc_preset {
+                    "Devnet" => "https://api.devnet.solana.com".to_string(),
+                    "Testnet" => "https://api.testnet.solana.com".to_string(),
+                    "Mainnet-Beta" => "https://api.mainnet-beta.solana.com".to_string(),
+                    _ => Text::new("Enter custom RPC URL:").prompt()?,
+                };
+
+                let keypair_path = Text::new("Keypair path:")
+                    .with_default("~/.config/solana/id.json")
+                    .prompt()?;
+
+                let commitment = Select::new(
+                    "Commitment level:",
+                    vec!["confirmed", "finalized", "processed"],
+                )
+                .prompt()?;
+
+                let config_content = format!(
+                    "rpc-url = \"{rpc_url}\"\nkeypair-path = \"{keypair_path}\"\ncommitment-level \
+                     = \"{commitment}\"\n"
+                );
+
+                let config_path = dirs::config_dir()
+                    .ok_or_else(|| anyhow::anyhow!("Could not find config directory"))?
+                    .join("scilla.toml");
+
+                std::fs::create_dir_all(config_path.parent().unwrap())?;
+                std::fs::write(&config_path, config_content)?;
+
+                println!(
+                    "{}",
+                    style(format!("Config saved to: {}", config_path.display()))
+                        .green()
+                        .bold()
+                );
+            }
+            ConfigCommand::Edit => {
+                let config_path = dirs::config_dir()
+                    .ok_or_else(|| anyhow::anyhow!("Could not find config directory"))?
+                    .join("scilla.toml");
+
+                let editor = std::env::var("EDITOR").unwrap_or_else(|_| "nano".to_string());
+
+                std::process::Command::new(&editor)
+                    .arg(&config_path)
+                    .status()
+                    .map_err(|e| anyhow::anyhow!("Failed to open editor '{editor}': {e}"))?;
+
+                println!("{}", style("Config file edited.").green());
+            }
+            ConfigCommand::GoBack => return Ok(CommandExec::GoBack),
         }
+
+        Ok(CommandExec::Process(()))
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -76,6 +76,6 @@ impl fmt::Display for CommandGroup {
             CommandGroup::ScillaConfig => "ScillaConfig",
             CommandGroup::Exit => "Exit",
         };
-        write!(f, "{}", command)
+        write!(f, "{command}")
     }
 }

--- a/src/commands/stake.rs
+++ b/src/commands/stake.rs
@@ -4,7 +4,7 @@ use {
         constants::ACTIVE_STAKE_EPOCH_BOUND,
         context::ScillaContext,
         error::ScillaResult,
-        misc::helpers::{SolAmount, build_and_send_tx, lamports_to_sol, sol_to_lamports},
+        misc::helpers::{build_and_send_tx, lamports_to_sol, sol_to_lamports, SolAmount},
         prompt::prompt_data,
         ui::show_spinner,
     },
@@ -62,7 +62,7 @@ impl fmt::Display for StakeCommand {
             StakeCommand::History => "History",
             StakeCommand::GoBack => "Go Back",
         };
-        write!(f, "{}", command)
+        write!(f, "{command}")
     }
 }
 
@@ -114,7 +114,7 @@ async fn process_deactivate_stake_account(
     }
 
     let stake_state: StakeStateV2 = bincode::deserialize(&account.data)
-        .map_err(|e| anyhow::anyhow!("Failed to deserialize stake account: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to deserialize stake account: {e}"))?;
 
     match stake_state {
         StakeStateV2::Stake(meta, stake, _) => {
@@ -149,8 +149,8 @@ async fn process_deactivate_stake_account(
         "\n{} {}\n{}\n{}",
         style("Stake Deactivated Successfully!").green().bold(),
         style("(Cooldown will take 1-2 epochs ≈ 2-4 days)").yellow(),
-        style(format!("Stake Account: {}", stake_pubkey)).yellow(),
-        style(format!("Signature: {}", signature)).cyan()
+        style(format!("Stake Account: {stake_pubkey}")).yellow(),
+        style(format!("Signature: {signature}")).cyan()
     );
 
     Ok(())
@@ -171,7 +171,7 @@ async fn process_withdraw_stake(
     }
 
     let stake_state: StakeStateV2 = bincode::deserialize(&account.data)
-        .map_err(|e| anyhow::anyhow!("Failed to deserialize stake account: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to deserialize stake account: {e}"))?;
 
     match stake_state {
         StakeStateV2::Stake(meta, stake, _) => {
@@ -240,10 +240,10 @@ async fn process_withdraw_stake(
     println!(
         "\n{} {}\n{}\n{}\n{}",
         style("Stake Withdrawn Successfully!").green().bold(),
-        style(format!("From Stake Account: {}", stake_pubkey)).yellow(),
-        style(format!("To Recipient: {}", recipient)).yellow(),
-        style(format!("Amount: {} SOL", amount_sol)).cyan(),
-        style(format!("Signature: {}", signature)).cyan()
+        style(format!("From Stake Account: {stake_pubkey}")).yellow(),
+        style(format!("To Recipient: {recipient}")).yellow(),
+        style(format!("Amount: {amount_sol} SOL")).cyan(),
+        style(format!("Signature: {signature}")).cyan()
     );
 
     Ok(())

--- a/src/commands/vote.rs
+++ b/src/commands/vote.rs
@@ -1,20 +1,20 @@
 use {
     crate::{
-        ScillaContext, ScillaResult,
         commands::CommandExec,
         misc::helpers::{
-            Commission, SolAmount, build_and_send_tx, lamports_to_sol, read_keypair_from_path,
+            build_and_send_tx, lamports_to_sol, read_keypair_from_path, Commission, SolAmount,
         },
         prompt::prompt_data,
         ui::show_spinner,
+        ScillaContext, ScillaResult,
     },
     ::console::style,
     anyhow::{anyhow, bail},
-    comfy_table::{Cell, Table, presets::UTF8_FULL},
+    comfy_table::{presets::UTF8_FULL, Cell, Table},
     solana_keypair::{Keypair, Signer},
     solana_pubkey::Pubkey,
     solana_vote_program::{
-        vote_instruction::{self, CreateVoteAccountConfig, withdraw},
+        vote_instruction::{self, withdraw, CreateVoteAccountConfig},
         vote_state::{VoteAuthorize, VoteInit, VoteStateV4},
     },
     std::{fmt, path::PathBuf},
@@ -51,7 +51,7 @@ impl fmt::Display for VoteCommand {
             VoteCommand::ShowVoteAccount => "Show Vote Account",
             VoteCommand::GoBack => "Go Back",
         };
-        write!(f, "{}", text)
+        write!(f, "{text}")
     }
 }
 
@@ -151,28 +151,21 @@ async fn process_create_vote_account(
 
     if fee_payer_pubkey == &vote_account_pubkey {
         bail!(
-            "Fee payer {} cannot be the same as vote account {}",
-            fee_payer_pubkey,
-            vote_account_pubkey
+            "Fee payer {fee_payer_pubkey} cannot be the same as vote account {vote_account_pubkey}"
         );
     }
     if vote_account_pubkey == identity_pubkey {
         bail!(
-            "Vote account {} cannot be the same as identity {}",
-            vote_account_pubkey,
-            identity_pubkey
+            "Vote account {vote_account_pubkey} cannot be the same as identity {identity_pubkey}"
         );
     }
 
     // checking if vote account already exists
     if let Ok(response) = ctx.rpc().get_account(&vote_account_pubkey).await {
         let err_msg = if response.owner == solana_vote_program::id() {
-            format!("Vote account {} already exists", vote_account_pubkey)
+            format!("Vote account {vote_account_pubkey} already exists")
         } else {
-            format!(
-                "Account {} already exists and is not a vote account",
-                vote_account_pubkey
-            )
+            format!("Account {vote_account_pubkey} already exists and is not a vote account")
         };
         bail!(err_msg)
     }
@@ -231,10 +224,10 @@ async fn process_authorize_voter(
         .rpc()
         .get_account(vote_account_pubkey)
         .await
-        .map_err(|_| anyhow!("{} account does not exist", vote_account_pubkey))?;
+        .map_err(|_| anyhow!("{vote_account_pubkey} account does not exist"))?;
 
     if vote_account.owner != solana_vote_program::id() {
-        bail!("{} is not a vote account", vote_account_pubkey);
+        bail!("{vote_account_pubkey} is not a vote account");
     }
 
     let vote_state = VoteStateV4::deserialize(&vote_account.data, vote_account_pubkey)
@@ -290,10 +283,10 @@ async fn process_sol_withdraw_from_vote_account(
         .rpc()
         .get_account(vote_account_pubkey)
         .await
-        .map_err(|_| anyhow!("{} account does not exist", vote_account_pubkey))?;
+        .map_err(|_| anyhow!("{vote_account_pubkey} account does not exist"))?;
 
     if vote_account.owner != solana_vote_program::id() {
-        bail!("{} is not a vote account", vote_account_pubkey);
+        bail!("{vote_account_pubkey} is not a vote account");
     }
 
     let vote_state = VoteStateV4::deserialize(&vote_account.data, vote_account_pubkey)
@@ -334,10 +327,10 @@ async fn process_fetch_vote_account(
         .rpc()
         .get_account(vote_account_pubkey)
         .await
-        .map_err(|_| anyhow!("{} account does not exist", vote_account_pubkey))?;
+        .map_err(|_| anyhow!("{vote_account_pubkey} account does not exist"))?;
 
     if vote_account.owner != solana_vote_program::id() {
-        bail!("{} is not a vote account", vote_account_pubkey);
+        bail!("{vote_account_pubkey} is not a vote account");
     }
 
     let vote_state = VoteStateV4::deserialize(&vote_account.data, vote_account_pubkey)
@@ -370,7 +363,7 @@ async fn process_fetch_vote_account(
         ])
         .add_row(vec![
             Cell::new("Account Balance"),
-            Cell::new(format!("{} SOL", balance_sol)),
+            Cell::new(format!("{balance_sol} SOL")),
         ])
         .add_row(vec![
             Cell::new("Validator Identity"),
@@ -402,7 +395,7 @@ async fn process_fetch_vote_account(
         ]);
 
     println!("\n{}", style("VOTE ACCOUNT INFORMATION").green().bold());
-    println!("{}", table);
+    println!("{table}");
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,10 +14,10 @@ pub fn scilla_config_path() -> PathBuf {
 pub fn expand_tilde(path: &str) -> PathBuf {
     // On TOMLs, ~ is not expanded, so do it manually
 
-    if let Some(stripped) = path.strip_prefix("~/")
-        && let Some(home) = home_dir()
-    {
-        return home.join(stripped);
+    if let Some(stripped) = path.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return home.join(stripped);
+        }
     }
     PathBuf::from(path)
 }

--- a/src/misc/helpers.rs
+++ b/src/misc/helpers.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{ScillaContext, constants::LAMPORTS_PER_SOL},
+    crate::{constants::LAMPORTS_PER_SOL, ScillaContext},
     anyhow::{anyhow, bail},
     solana_instruction::Instruction,
     solana_keypair::{EncodableKey, Keypair, Signature, Signer},
@@ -13,13 +13,10 @@ pub fn trim_and_parse<T: FromStr>(s: &str, field_name: &str) -> anyhow::Result<O
     if trimmed.is_empty() {
         Ok(None)
     } else {
-        trimmed.parse().map(Some).map_err(|_| {
-            anyhow!(
-                "Invalid {}: {}. Must be a valid number",
-                field_name,
-                trimmed
-            )
-        })
+        trimmed
+            .parse()
+            .map(Some)
+            .map_err(|_| anyhow!("Invalid {field_name}: {trimmed}. Must be a valid number"))
     }
 }
 
@@ -41,7 +38,7 @@ impl FromStr for Commission {
             None => return Ok(Commission(0)), // default to 0%
         };
         if commission > 100 {
-            bail!("Commission must be between 0 and 100, got {}", commission);
+            bail!("Commission must be between 0 and 100, got {commission}");
         }
         Ok(Commission(commission))
     }
@@ -68,10 +65,10 @@ impl FromStr for SolAmount {
             .ok_or_else(|| anyhow!("Amount cannot be empty. Please enter a SOL amount"))?;
 
         if sol <= 0.0 || !sol.is_finite() {
-            bail!("Amount must be a positive finite number, got {}", sol);
+            bail!("Amount must be a positive finite number, got {sol}");
         }
         if sol * LAMPORTS_PER_SOL as f64 > u64::MAX as f64 {
-            bail!("Amount too large: {} SOL would overflow", sol);
+            bail!("Amount too large: {sol} SOL would overflow");
         }
         Ok(SolAmount(sol))
     }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,7 +1,7 @@
 use {
     crate::commands::{
-        Command, CommandGroup, account::AccountCommand, cluster::ClusterCommand,
-        config::ConfigCommand, stake::StakeCommand, vote::VoteCommand,
+        account::AccountCommand, cluster::ClusterCommand, config::ConfigCommand,
+        stake::StakeCommand, vote::VoteCommand, Command, CommandGroup,
     },
     inquire::{Select, Text},
     std::str::FromStr,


### PR DESCRIPTION
Adds Scilla configuration management commands:
- Show: displays current config in table format
- Generate: interactive wizard for RPC/keypair/commitment settings
- Edit: opens config file in $EDITOR

Config stored at ~/.config/scilla.toml