### PR TITLE
added deserialize_with_bincode fn in helper.rs

### DIFF
--- a/src/commands/account.rs
+++ b/src/commands/account.rs
@@ -3,7 +3,7 @@ use {
         commands::CommandExec,
         context::ScillaContext,
         error::ScillaResult,
-        misc::helpers::lamports_to_sol,
+        misc::helpers::{deserialize_with_bincode, lamports_to_sol},
         prompt::prompt_data,
         ui::{print_error, show_spinner},
     },
@@ -249,7 +249,7 @@ async fn fetch_largest_accounts(ctx: &ScillaContext) -> anyhow::Result<()> {
 async fn fetch_nonce_account(ctx: &ScillaContext, pubkey: &Pubkey) -> anyhow::Result<()> {
     let account = ctx.rpc().get_account(pubkey).await?;
 
-    let versions = bincode::deserialize::<Versions>(&account.data)
+    let versions = deserialize_with_bincode::<Versions>(&account.data)
         .map_err(|e| anyhow::anyhow!("Failed to deserialize nonce account data: {e}"))?;
 
     let solana_nonce::state::State::Initialized(data) = versions.state() else {

--- a/src/commands/stake.rs
+++ b/src/commands/stake.rs
@@ -5,8 +5,7 @@ use {
         context::ScillaContext,
         error::ScillaResult,
         misc::helpers::{
-            SolAmount, build_and_send_tx, fetch_account_with_epoch, lamports_to_sol,
-            sol_to_lamports,
+            SolAmount, build_and_send_tx, deserialize_with_bincode, fetch_account_with_epoch, lamports_to_sol, sol_to_lamports
         },
         prompt::prompt_data,
         ui::show_spinner,
@@ -122,7 +121,7 @@ async fn process_deactivate_stake_account(
         bail!("Account is not owned by the stake program");
     }
 
-    let stake_state: StakeStateV2 = bincode::deserialize(&account.data)
+    let stake_state: StakeStateV2 = deserialize_with_bincode(&account.data)
         .map_err(|e| anyhow::anyhow!("Failed to deserialize stake account: {e}"))?;
 
     match stake_state {
@@ -179,7 +178,7 @@ async fn process_withdraw_stake(
         bail!("Account is not owned by the stake program");
     }
 
-    let stake_state: StakeStateV2 = bincode::deserialize(&account.data)
+    let stake_state: StakeStateV2 = deserialize_with_bincode(&account.data)
         .map_err(|e| anyhow::anyhow!("Failed to deserialize stake account: {e}"))?;
 
     match stake_state {

--- a/src/misc/helpers.rs
+++ b/src/misc/helpers.rs
@@ -1,6 +1,6 @@
 use {
     crate::{ScillaContext, constants::LAMPORTS_PER_SOL},
-    anyhow::{anyhow, bail},
+    anyhow::{anyhow, bail, Context},
     solana_account::Account,
     solana_epoch_info::EpochInfo,
     solana_instruction::Instruction,
@@ -10,7 +10,13 @@ use {
     solana_transaction::Transaction,
     std::{path::Path, str::FromStr},
     tokio::try_join,
+    serde::de::DeserializeOwned,
 };
+
+/// Generic helper that wraps bincode::deserialize and returns anyhow::Result
+pub fn deserialize_with_bincode<T: DeserializeOwned>(data: &[u8]) -> anyhow::Result<T> {
+    bincode::deserialize(data).context("Failed to deserialize with bincode")
+}
 
 pub fn trim_and_parse<T: FromStr>(s: &str, field_name: &str) -> anyhow::Result<Option<T>> {
     let trimmed = s.trim();


### PR DESCRIPTION
feat: add generic helper for bincode deserialization

``` rust 
/// Generic helper that wraps bincode::deserialize and returns anyhow::Result
pub fn deserialize_with_bincode<T: DeserializeOwned>(data: &[u8]) -> anyhow::Result<T> {
    bincode::deserialize(data).context("Failed to deserialize with bincode")
}
```

- Add deserialize_with_bincode helper in misc/helper.rs
- Replace all bincode::deserialize calls with the helper