### PR TITLE
refactor: remove unused asyncs

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -80,16 +80,16 @@ fn get_commitment_levels() -> Vec<CommitmentLevel> {
 }
 
 impl ConfigCommand {
-    pub async fn process_command(&self) -> ScillaResult<()> {
+    pub fn process_command(&self) -> ScillaResult<()> {
         match self {
             ConfigCommand::Show => {
-                show_config().await?;
+                show_config()?;
             }
             ConfigCommand::Generate => {
-                generate_config().await?;
+                generate_config()?;
             }
             ConfigCommand::Edit => {
-                edit_config().await?;
+                edit_config()?;
             }
             ConfigCommand::GoBack => return Ok(CommandExec::GoBack),
         };
@@ -98,8 +98,8 @@ impl ConfigCommand {
     }
 }
 
-async fn show_config() -> anyhow::Result<()> {
-    let config = ScillaConfig::load().await?;
+fn show_config() -> anyhow::Result<()> {
+    let config = ScillaConfig::load()?;
 
     let mut table = Table::new();
     table
@@ -124,7 +124,7 @@ async fn show_config() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn generate_config() -> anyhow::Result<()> {
+pub fn generate_config() -> anyhow::Result<()> {
     // Check if config already exists
     let config_path = scilla_config_path();
     if config_path.exists() {
@@ -220,8 +220,8 @@ pub async fn generate_config() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn edit_config() -> anyhow::Result<()> {
-    let mut config = ScillaConfig::load().await?;
+fn edit_config() -> anyhow::Result<()> {
+    let mut config = ScillaConfig::load()?;
 
     println!("\n{}", style("Edit Config").green().bold());
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -55,7 +55,7 @@ impl Command {
             Command::Transaction(transaction_command) => {
                 transaction_command.process_command(ctx).await
             }
-            Command::ScillaConfig(config_command) => config_command.process_command().await,
+            Command::ScillaConfig(config_command) => config_command.process_command(),
             Command::Exit => Ok(CommandExec::Exit),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,7 +57,7 @@ impl Default for ScillaConfig {
 }
 
 impl ScillaConfig {
-    pub async fn load() -> Result<ScillaConfig, ScillaError> {
+    pub fn load() -> Result<ScillaConfig, ScillaError> {
         let scilla_config_path = scilla_config_path();
 
         if !scilla_config_path.exists() {
@@ -80,7 +80,7 @@ impl ScillaConfig {
                 style("Let's set up your configuration to get started.\n").cyan()
             );
 
-            crate::commands::config::generate_config().await?;
+            crate::commands::config::generate_config()?;
 
             println!(
                 "\n{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> ScillaResult<()> {
             .cyan()
     );
 
-    let config = ScillaConfig::load().await?;
+    let config = ScillaConfig::load()?;
     let ctx = ScillaContext::from_config(config)?;
 
     loop {


### PR DESCRIPTION
### Problem

there are some functions that are declared as `async` but execute totally synchronously

### Solution

remove unused `async fn` declarations