### PR TITLE
feat: Implement SOL Transfer and Fix Nonce Viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,6 +1975,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
+ "solana-system-interface 3.0.0",
  "solana-transaction",
  "solana-transaction-status",
  "solana-vote-interface",
@@ -2384,7 +2385,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
  "solana-short-vec",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -2629,7 +2630,7 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -3024,7 +3025,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 3.0.0",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
 ]
@@ -3048,6 +3049,21 @@ dependencies = [
  "solana-msg",
  "solana-program-error",
  "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14591d6508042ebefb110305d3ba761615927146a26917ade45dc332d8e1ecde"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-address 2.0.0",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
 ]
 
 [[package]]
@@ -3172,7 +3188,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
@@ -3247,7 +3263,7 @@ dependencies = [
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-short-vec",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ solana-sdk-ids = "3"
 base64 = "0.22.1"
 bs58 = "0.5.1"
 solana-transaction-status = "3.1.4"
+solana-system-interface = { version = "3.0.0", features = ["bincode"] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
Summary
This PR implements the missing "Transfer SOL" functionality and fixes a crash in the Nonce Account viewer.

Changes
1. New Feature: Transfer SOL
Implemented AccountCommand::Transfer (previously a todo!).
Added 
process_transfer
 helper to handle the logic.
Rent Exemption Safety: Automatically checks if the recipient is a new account (0 balance). If so, ensures the transfer amount is at least sufficient for rent exemption (~0.00089 SOL).
Self-Transfer Protection: Prevents accidentally sending SOL to the sender's own address.
Table Output: Success messages are now displayed in a clean table format.
2. Fix: Nonce Account Viewer Crash
Fixed a bug where AccountCommand::NonceAccount would panic with an unexpected end of file error if the target account had no data.
Added a check: if account.data.is_empty(), return a friendly error message.
3. Dependencies
Added solana-system-interface (feature bincode) to access the transfer instruction helper.

<img width="1219" height="869" alt="Screenshot from 2025-12-30 01-29-34" src="https://github.com/user-attachments/assets/5535dfe0-5cda-4d8e-8f83-3f02c14671cd" />
