### PR TITLE
feat(cluster): add epoch progress 

### DIFF
--- a/src/commands/cluster.rs
+++ b/src/commands/cluster.rs
@@ -138,7 +138,6 @@ async fn fetch_epoch_info(ctx: &ScillaContext) -> anyhow::Result<()> {
 
     println!("\n{}", style("EPOCH INFORMATION").green().bold());
     println!("{table}");
-    println!();
 
     Ok(())
 }


### PR DESCRIPTION
Closes #82

- Added "Epoch Progress" percentage row to `Epoch Info` command (e.g., `40.46%`) to help track schedule.
-Epoch progress makes it easier to understand where the cluster is within the current epoch at a glance (useful for timing/operations that are epoch-bound).

<img width="333" height="295" alt="Screenshot 2026-01-01 at 3 22 13 PM" src="https://github.com/user-attachments/assets/19f23856-70d5-4379-ad0f-16c6c59bb844" />
