### PR TITLE
feat: add NavStack type

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ pub mod context;
 pub mod error;
 pub mod misc;
 pub mod prompt;
-pub mod types;
 pub mod ui;
 
 #[tokio::main(flavor = "multi_thread")]

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -1,1 +1,4 @@
 pub mod helpers;
+pub mod navigation;
+
+pub use navigation::*;


### PR DESCRIPTION
 ## Summary

Adds navigation types to handle in-section navigation.

## What's in here

- `Section` enum with per-section max depth
- `SectionNav` for tracking depth within a section (bounded, no heap)
- `AppNav` for managing main menu vs in-section state
- Tests covering normal flow and edge cases

Next step: integrate into the command flow.

First step to close #61