### PR TITLE
feat: add confirmation prompts for destructive operations

### DIFF
--- a/src/commands/stake.rs
+++ b/src/commands/stake.rs
@@ -11,7 +11,7 @@ use {
             check_minimum_balance, fetch_account_with_epoch, lamports_to_sol,
             read_keypair_from_path, sol_to_lamports,
         },
-        prompt::{prompt_input_data, prompt_keypair_path},
+        prompt::{prompt_confirmation, prompt_input_data, prompt_keypair_path},
         ui::show_spinner,
     },
     anyhow::{anyhow, bail},
@@ -142,6 +142,12 @@ impl StakeCommand {
             StakeCommand::Deactivate => {
                 let stake_pubkey: Pubkey =
                     prompt_input_data("Enter Stake Account Pubkey to Deactivate:");
+
+                if !prompt_confirmation("Are you sure you want to deactivate this stake?") {
+                    println!("{}", style("Deactivation cancelled.").yellow());
+                    return CommandFlow::Process(());
+                }
+
                 show_spinner(
                     self.spinner_msg(),
                     process_deactivate_stake_account(ctx, &stake_pubkey),
@@ -153,6 +159,14 @@ impl StakeCommand {
                     prompt_input_data("Enter Stake Account Pubkey to Withdraw from:");
                 let recipient: Pubkey = prompt_input_data("Enter Recipient Address:");
                 let amount: SolAmount = prompt_input_data("Enter Amount to Withdraw (SOL):");
+
+                if !prompt_confirmation(&format!(
+                    "Are you sure you want to withdraw {} SOL?",
+                    amount.value()
+                )) {
+                    println!("{}", style("Withdrawal cancelled.").yellow());
+                    return CommandFlow::Process(());
+                }
 
                 show_spinner(
                     self.spinner_msg(),

--- a/src/commands/vote.rs
+++ b/src/commands/vote.rs
@@ -6,7 +6,7 @@ use {
             Commission, SolAmount, build_and_send_tx, fetch_account_with_epoch, lamports_to_sol,
             read_keypair_from_path,
         },
-        prompt::{prompt_input_data, prompt_keypair_path},
+        prompt::{prompt_confirmation, prompt_input_data, prompt_keypair_path},
         ui::show_spinner,
     },
     anyhow::{anyhow, bail},
@@ -136,6 +136,11 @@ impl VoteCommand {
                 let withdraw_authority_keypair_path =
                     prompt_keypair_path("Enter Withdraw Authority Keypair Path:", ctx);
                 let destination_pubkey: Pubkey = prompt_input_data("Enter Destination Address:");
+
+                if !prompt_confirmation("Are you sure you want to close this vote account?") {
+                    println!("{}", style("Close vote account cancelled.").yellow());
+                    return CommandFlow::Process(());
+                }
 
                 show_spinner(
                     self.spinner_msg(),

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -9,7 +9,7 @@ use {
         ui::print_error,
     },
     console::style,
-    inquire::{InquireError, Select, Text},
+    inquire::{Confirm, InquireError, Select, Text},
     std::{fmt::Display, path::PathBuf, process::exit, str::FromStr},
 };
 pub fn prompt_for_command() -> anyhow::Result<Command> {
@@ -228,4 +228,8 @@ pub fn prompt_keypair_path(msg: &str, ctx: &ScillaContext) -> PathBuf {
             }
         }
     }
+}
+
+pub fn prompt_confirmation(msg: &str) -> bool {
+    Confirm::new(msg).prompt().unwrap_or(false)
 }


### PR DESCRIPTION
Closes #86  

Adds safety confirmation prompts (y/n) to critical commands that move funds or change stake state, preventing accidental execution.

Changes:

Added prompts to Stake > Deactivate and Stake > Withdraw.
Added prompt to Vote > Close Vote Account.

<img width="545" height="141" alt="Screenshot 2026-01-02 at 12 57 24 PM" src="https://github.com/user-attachments/assets/e3ff7d49-f169-47a4-8428-f14c24cbbd8b" />

