### PR TITLE
feat: add get address from keypair command

### DIFF
--- a/crates/scilla/src/commands/main_command.rs
+++ b/crates/scilla/src/commands/main_command.rs
@@ -3,9 +3,9 @@ use {
         commands::{Command, CommandFlow, navigation::NavigationSection},
         context::ScillaContext,
         prompt::{
-            prompt_account_section, prompt_cluster_section, prompt_config_section,
-            prompt_program_section, prompt_stake_section, prompt_transaction_section,
-            prompt_vote_section,
+            prompt_account_section, prompt_address_section, prompt_cluster_section,
+            prompt_config_section, prompt_program_section, prompt_stake_section,
+            prompt_transaction_section, prompt_vote_section,
         },
     },
     anyhow::Ok,
@@ -20,6 +20,7 @@ pub enum MainCommand {
     Vote,
     Transaction,
     ScillaConfig,
+    Address,
     Exit,
 }
 
@@ -33,6 +34,7 @@ impl fmt::Display for MainCommand {
             MainCommand::Vote => "Vote",
             MainCommand::Transaction => "Transaction",
             MainCommand::ScillaConfig => "Scilla Config",
+            MainCommand::Address => "Address",
             MainCommand::Exit => "Exit",
         };
         f.write_str(label)
@@ -52,6 +54,7 @@ impl Command for MainCommand {
             MainCommand::Transaction => prompt_transaction_section()?.process_command(ctx).await?,
             MainCommand::Program => prompt_program_section()?.process_command(ctx).await?,
             MainCommand::ScillaConfig => prompt_config_section()?.process_command(ctx).await?,
+            MainCommand::Address => prompt_address_section()?.process_command(ctx).await?,
             MainCommand::Exit => {
                 return Ok(CommandFlow::Exit);
             }

--- a/crates/scilla/src/commands/mod.rs
+++ b/crates/scilla/src/commands/mod.rs
@@ -5,6 +5,7 @@ use {
 };
 
 pub mod account;
+pub mod address;
 pub mod cluster;
 pub mod config;
 pub mod main_command;

--- a/crates/scilla/src/commands/navigation.rs
+++ b/crates/scilla/src/commands/navigation.rs
@@ -3,9 +3,9 @@ use {
         commands::{Command, CommandFlow, program::ProgramCommand},
         context::ScillaContext,
         prompt::{
-            prompt_account_section, prompt_cluster_section, prompt_config_section,
-            prompt_main_section, prompt_program_section, prompt_stake_section,
-            prompt_transaction_section, prompt_vote_section,
+            prompt_account_section, prompt_address_section, prompt_cluster_section,
+            prompt_config_section, prompt_main_section, prompt_program_section,
+            prompt_stake_section, prompt_transaction_section, prompt_vote_section,
         },
     },
     std::fmt::{self, Display},
@@ -31,6 +31,7 @@ pub enum NavigationSection {
     ProgramLegacy,
     ProgramV4,
 
+    Address,
     Stake,
     Vote,
     Transaction,
@@ -44,6 +45,7 @@ impl Display for NavigationSection {
             NavigationSection::Main => "Main",
             NavigationSection::Account => "Account",
             NavigationSection::Cluster => "Cluster",
+            NavigationSection::Address => "Address",
             NavigationSection::Program => "Program",
             NavigationSection::ProgramLegacy => "ProgramLegacy",
             NavigationSection::ProgramV4 => "ProgramV4",
@@ -76,6 +78,11 @@ impl NavigationSection {
 
             NavigationSection::Cluster => {
                 let cmd = prompt_cluster_section()?;
+                cmd.process_command(ctx).await
+            }
+
+            NavigationSection::Address => {
+                let cmd = prompt_address_section()?;
                 cmd.process_command(ctx).await
             }
 

--- a/crates/scilla/src/prompt.rs
+++ b/crates/scilla/src/prompt.rs
@@ -3,6 +3,7 @@ use {
         commands::{
             Command,
             account::AccountCommand,
+            address::AddressCommand,
             cluster::ClusterCommand,
             config::ConfigCommand,
             main_command::MainCommand,
@@ -32,6 +33,7 @@ pub fn prompt_main_section() -> anyhow::Result<impl Command> {
             MainCommand::Vote,
             MainCommand::Transaction,
             MainCommand::ScillaConfig,
+            MainCommand::Address,
             MainCommand::Exit,
         ],
     )
@@ -51,7 +53,6 @@ pub fn prompt_account_section() -> anyhow::Result<AccountCommand> {
             AccountCommand::LargestAccounts,
             AccountCommand::NonceAccount,
             AccountCommand::Rent,
-            AccountCommand::GetAddress,
             AccountCommand::GoBack,
         ],
     )
@@ -161,6 +162,20 @@ pub fn prompt_transaction_section() -> anyhow::Result<TransactionCommand> {
             TransactionCommand::SendTransaction,
             TransactionCommand::SimulateTransaction,
             TransactionCommand::GoBack,
+        ],
+    )
+    .prompt()?;
+
+    Ok(choice)
+}
+
+pub fn prompt_address_section() -> anyhow::Result<AddressCommand> {
+    let choice = Select::new(
+        "Address Command:",
+        vec![
+            AddressCommand::Address,
+            AddressCommand::DerivePda,
+            AddressCommand::GoBack,
         ],
     )
     .prompt()?;


### PR DESCRIPTION
## Summary
- Add `GetAddress` command under Account section to resolve public key from a keypair JSON file (`solana address -k` equivalent)
- Fix whitespace trimming in `prompt_keypair_path` to prevent path resolution errors

## Test plan
- Run binary → Account → Get address from keypair → provide keypair path → verify printed address matches `solana address -k <path>`