### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With Scilla, you can easily **inspect on-chain data**, **query cluster state**, 
 ```bash
 # Clone and build
 git clone https://github.com/blueshift-gg/Scilla
-cd Scilla
+cd Scilla/crates/scilla
 cargo install --path .
 ```
 ---


### PR DESCRIPTION
## Description

When running a fresh install on mac the following error is encountered with the existing instructions:
`error: found a virtual manifest at ./github.com/blueshift-gg/Scilla/Cargo.toml instead of a package manifest`

Adjusting the install instructions to run from the internal crates dir works 

## Related Issue

- NA

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests (adding or updating tests)

