### PR TITLE
feat: Implement address look up table command group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2891,6 +2891,7 @@ dependencies = [
  "serde_json",
  "solana-account",
  "solana-account-decoder",
+ "solana-address-lookup-table-interface",
  "solana-clock",
  "solana-commitment-config",
  "solana-epoch-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ solana-nonce = "3.0.0"
 solana-transaction-status = "3.1.4"
 solana-system-interface = { version = "3.0.0", features = ["bincode"] }
 solana-account-decoder = "3.1.6"
+solana-address-lookup-table-interface = "3.0.1"

--- a/crates/scilla/Cargo.toml
+++ b/crates/scilla/Cargo.toml
@@ -50,6 +50,7 @@ solana-nonce.workspace = true
 solana-transaction-status.workspace = true
 solana-system-interface.workspace = true
 solana-account-decoder.workspace = true
+solana-address-lookup-table-interface.workspace = true
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/crates/scilla/src/commands/alt.rs
+++ b/crates/scilla/src/commands/alt.rs
@@ -77,7 +77,7 @@ impl Command for AltCommand {
                 } else {
                     authority_input.parse()?
                 };
-                
+
                 let payer_address_input: String =
                     prompt_input_data("Enter Payer Address (defaults to config keypair) :");
                 let payer_address = if payer_address_input.trim().is_empty() {
@@ -85,8 +85,12 @@ impl Command for AltCommand {
                 } else {
                     payer_address_input.parse()?
                 };
-                
-                show_spinner(self.spinner_msg(), create_table(ctx, authority_address, payer_address)).await;
+
+                show_spinner(
+                    self.spinner_msg(),
+                    create_table(ctx, authority_address, payer_address),
+                )
+                .await;
             }
 
             AltCommand::Get => {
@@ -141,8 +145,7 @@ impl Command for AltCommand {
 
 async fn create_table(ctx: &ScillaContext, authority: Pubkey, payer: Pubkey) -> anyhow::Result<()> {
     let recent_slot = ctx.rpc().get_slot().await?;
-    let (instruction, pubkey) =
-        create_lookup_table(authority, payer, recent_slot);
+    let (instruction, pubkey) = create_lookup_table(authority, payer, recent_slot);
 
     let signature = build_and_send_tx(ctx, &[instruction], &[ctx.keypair()]).await?;
 

--- a/crates/scilla/src/commands/alt.rs
+++ b/crates/scilla/src/commands/alt.rs
@@ -5,9 +5,7 @@ use {
             navigation::{NavigationSection, NavigationTarget},
         },
         context::ScillaContext,
-        misc::helpers::{
-            build_and_send_tx, parse_addresses_string_to_pubkeys, unpack_option_to_string,
-        },
+        misc::helpers::{build_and_send_tx, parse_addresses_string_to_pubkeys},
         prompt::prompt_input_data,
         ui::show_spinner,
     },
@@ -179,7 +177,12 @@ async fn get_lookup_table(ctx: &ScillaContext, pubkey: &Pubkey) -> anyhow::Resul
         .add_row(vec![Cell::new("LookUp Table Address"), Cell::new(pubkey)])
         .add_row(vec![
             Cell::new("Authority"),
-            Cell::new(unpack_option_to_string(&alt_table_data.meta.authority)),
+            Cell::new(
+                alt_table_data
+                    .meta
+                    .authority
+                    .map_or("None".to_string(), |a| a.to_string()),
+            ),
         ])
         .add_row(vec![
             Cell::new("Deactivation Slot"),

--- a/crates/scilla/src/commands/alt.rs
+++ b/crates/scilla/src/commands/alt.rs
@@ -1,0 +1,193 @@
+use std::fmt::{Display, Formatter, Result};
+
+use comfy_table::{Table, Cell, presets::UTF8_FULL};
+use console::style;
+use solana_address_lookup_table_interface::{instruction::{create_lookup_table, extend_lookup_table}, state::AddressLookupTable};
+use solana_keypair::Signer;
+use solana_pubkey::Pubkey;
+
+use crate::{commands::{Command, CommandFlow, navigation::{NavigationSection, NavigationTarget}}, context::ScillaContext, misc::helpers::{build_and_send_tx, parse_addresses_string_to_pubkeys, unpack_option_to_string}, prompt::prompt_input_data, ui::show_spinner};
+
+#[derive(Debug, Clone, Copy)]
+pub enum AltCommand {
+    Create,
+    Extend,
+    Get,
+    Freeze,
+    Deactivate,
+    Close,
+    GoBack,
+}
+
+impl AltCommand {
+    pub fn spinner_msg(&self) -> &'static str {
+        match self {
+            AltCommand::Create => "Creating Table",
+            AltCommand::Get => "Fetching Table",
+            AltCommand::Extend => "Extending Table",
+            AltCommand::Freeze => "Freezing Table",
+            AltCommand::Deactivate => "Deactivating Table",
+            AltCommand::Close => "Closing Table",
+            AltCommand::GoBack => "Going Back...",
+        }
+    }
+}
+
+impl Display for AltCommand {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        let command = match self {
+            AltCommand::Create => "Create ALT",
+            AltCommand::Extend => "Extend ALT",
+            AltCommand::Get => "Get ALT",
+            AltCommand::Freeze => "Freeze ALT",
+            AltCommand::Deactivate => "Deactivate ALT",
+            AltCommand::Close => "Close ALT",
+            AltCommand::GoBack => "Going Back...",
+        };
+        write!(f, "{command}")
+    }
+}
+
+// io
+impl Command for AltCommand {
+    async fn process_command(&self, ctx: &mut ScillaContext) -> anyhow::Result<CommandFlow> {
+        ctx.get_nav_context_mut()
+            .checked_push(NavigationSection::AddressLookupTable);
+        match self {
+            AltCommand::Create => {
+                show_spinner( self.spinner_msg(), create_table(ctx)).await;
+            }
+            
+            AltCommand::Get => {
+                let pubkey: Pubkey = prompt_input_data("Enter ALT Address :");
+                show_spinner( self.spinner_msg(), get_lookup_table(ctx, &pubkey)).await;
+            }
+            
+            AltCommand::Extend => {
+                let pubkey: Pubkey = prompt_input_data("Enter ALT Address :");
+                let addresses_string: String = prompt_input_data("Enter addresses to add (comma-separated) :");
+                show_spinner( self.spinner_msg(), extend_table(ctx, pubkey, &addresses_string)).await;
+            }
+            
+            AltCommand::Freeze => {
+                show_spinner( self.spinner_msg(), freeze_lookup_table(ctx)).await;
+            }
+            
+            AltCommand::Deactivate => {
+                show_spinner( self.spinner_msg(), deactivate_lookup_table(ctx)).await;
+            }
+            
+            AltCommand::Close => {
+                show_spinner( self.spinner_msg(), close_lookup_table(ctx)).await;
+            }
+            
+            AltCommand::GoBack => {
+                return Ok(CommandFlow::NavigateTo(NavigationTarget::PreviousSection));
+            }
+        }
+        Ok(CommandFlow::Processed)
+    }
+}
+
+async fn create_table(ctx: &ScillaContext) -> anyhow::Result<()> {
+    let recent_slot = ctx.rpc().get_slot().await?;
+    let (instruction, pubkey) = create_lookup_table(ctx.keypair().pubkey(), ctx.keypair().pubkey(), recent_slot);
+
+    let signature = build_and_send_tx(ctx, &[instruction], &[ctx.keypair()]).await?;
+
+    println!(
+        "{}\n{}\n{}",
+        style("Address Lookup Table created successfully!").yellow().bold(),
+        style(format!("ALT Address: {pubkey}")).cyan(),
+        style(format!("Signature: {signature}")).green()
+    );
+
+    Ok(())
+}
+
+async fn get_lookup_table(ctx: &ScillaContext, pubkey: &Pubkey) -> anyhow::Result<()> {
+    let account = ctx.rpc().get_account(pubkey).await?;
+    let alt_table_data = AddressLookupTable::deserialize(&account.data)?;
+
+    // Metadata table
+    let mut metadata_table = Table::new();
+    metadata_table
+        .load_preset(UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Field")
+                .add_attribute(comfy_table::Attribute::Bold)
+                .fg(comfy_table::Color::Cyan),
+            Cell::new("Value")
+                .add_attribute(comfy_table::Attribute::Bold)
+                .fg(comfy_table::Color::Cyan),
+        ])
+        .add_row(vec![Cell::new("LookUp Table Address"), Cell::new(pubkey)])
+        .add_row(vec![
+            Cell::new("Authority"),
+            Cell::new(unpack_option_to_string(&alt_table_data.meta.authority)),
+        ])
+        .add_row(vec![
+            Cell::new("Deactivation Slot"),
+            Cell::new(format!("{}", alt_table_data.meta.deactivation_slot)),
+        ])
+        .add_row(vec![Cell::new("Last Extended Slot"), Cell::new(format!("{}", alt_table_data.meta.last_extended_slot))]);
+    println!("{}\n{}", style("ALT METADATA").green().bold(), metadata_table);
+
+    if !alt_table_data.addresses.is_empty() {                                                            
+        let mut address_table = Table::new();
+        address_table
+            .load_preset(UTF8_FULL)
+            .set_header(vec![
+                Cell::new("Index")
+                    .add_attribute(comfy_table::Attribute::Bold)
+                    .fg(comfy_table::Color::Cyan),
+                Cell::new("Address")
+                    .add_attribute(comfy_table::Attribute::Bold)
+                    .fg(comfy_table::Color::Cyan),
+            ]);
+            
+        for (index, address) in alt_table_data.addresses.iter().enumerate() {
+            address_table.add_row(vec![
+                Cell::new(index),
+                Cell::new(address.to_string())  
+            ]);
+        }
+        println!("{}\n{}", style("ADDRESS LOOKUP TABLE").green().bold(), address_table);
+    } else {                                                                               
+        println!("{}", style("No addresses stored in this table").yellow());                             
+    }                                                                                    
+
+    Ok(())
+}
+
+async fn freeze_lookup_table(_ctx: &ScillaContext) -> anyhow::Result<()> {
+    todo!();
+    // Ok(())
+}
+
+async fn deactivate_lookup_table(_ctx: &ScillaContext) -> anyhow::Result<()> {
+    todo!();
+    // Ok(())
+}
+
+async fn extend_table(ctx: &ScillaContext, alt_address: Pubkey, address_strings: &str) -> anyhow::Result<()> {
+    let address_pubkeys: Vec<Pubkey> = parse_addresses_string_to_pubkeys(address_strings)?;
+    let address_len = address_pubkeys.len();
+    let instruction = extend_lookup_table(alt_address, *ctx.pubkey(), Some(*ctx.pubkey()), address_pubkeys);
+
+    let signature = build_and_send_tx(ctx, &[instruction], &[ctx.keypair()]).await?;
+
+    println!(
+        "{}\n{}\n{}\n{}",
+        style("Lookup Table extended successfully!").yellow().bold(),
+        style(format!("ALT Address: {alt_address}")).cyan(),
+        style(format!("Addresses Added: {}", address_len)).cyan(),
+        style(format!("Signature: {signature}")).green()
+    );
+    Ok(())
+}
+
+async fn close_lookup_table(_ctx: &ScillaContext) -> anyhow::Result<()> {
+    todo!();
+    // Ok(())
+}

--- a/crates/scilla/src/commands/alt.rs
+++ b/crates/scilla/src/commands/alt.rs
@@ -1,12 +1,29 @@
-use std::fmt::{Display, Formatter, Result};
-
-use comfy_table::{Table, Cell, presets::UTF8_FULL};
-use console::style;
-use solana_address_lookup_table_interface::{instruction::{close_lookup_table, create_lookup_table, deactivate_lookup_table, extend_lookup_table, freeze_lookup_table}, state::AddressLookupTable};
-use solana_keypair::Signer;
-use solana_pubkey::Pubkey;
-
-use crate::{commands::{Command, CommandFlow, navigation::{NavigationSection, NavigationTarget}}, context::ScillaContext, misc::helpers::{build_and_send_tx, parse_addresses_string_to_pubkeys, unpack_option_to_string}, prompt::prompt_input_data, ui::show_spinner};
+use {
+    crate::{
+        commands::{
+            Command, CommandFlow,
+            navigation::{NavigationSection, NavigationTarget},
+        },
+        context::ScillaContext,
+        misc::helpers::{
+            build_and_send_tx, parse_addresses_string_to_pubkeys, unpack_option_to_string,
+        },
+        prompt::prompt_input_data,
+        ui::show_spinner,
+    },
+    comfy_table::{Cell, Table, presets::UTF8_FULL},
+    console::style,
+    solana_address_lookup_table_interface::{
+        instruction::{
+            close_lookup_table, create_lookup_table, deactivate_lookup_table, extend_lookup_table,
+            freeze_lookup_table,
+        },
+        state::AddressLookupTable,
+    },
+    solana_keypair::Signer,
+    solana_pubkey::Pubkey,
+    std::fmt::{Display, Formatter, Result},
+};
 
 #[derive(Debug, Clone, Copy)]
 pub enum AltCommand {
@@ -55,41 +72,51 @@ impl Command for AltCommand {
             .checked_push(NavigationSection::AddressLookupTable);
         match self {
             AltCommand::Create => {
-                show_spinner( self.spinner_msg(), create_table(ctx)).await;
+                show_spinner(self.spinner_msg(), create_table(ctx)).await;
             }
-            
+
             AltCommand::Get => {
                 let alt_address: Pubkey = prompt_input_data("Enter ALT Address :");
-                show_spinner( self.spinner_msg(), get_lookup_table(ctx, &alt_address)).await;
+                show_spinner(self.spinner_msg(), get_lookup_table(ctx, &alt_address)).await;
             }
-            
+
             AltCommand::Extend => {
                 let alt_address: Pubkey = prompt_input_data("Enter ALT Address :");
-                let addresses_string: String = prompt_input_data("Enter addresses to add (comma-separated) :");
-                show_spinner( self.spinner_msg(), extend_table(ctx, alt_address, &addresses_string)).await;
+                let addresses_string: String =
+                    prompt_input_data("Enter addresses to add (comma-separated) :");
+                show_spinner(
+                    self.spinner_msg(),
+                    extend_table(ctx, alt_address, &addresses_string),
+                )
+                .await;
             }
-            
+
             AltCommand::Freeze => {
                 let alt_address: Pubkey = prompt_input_data("Enter ALT Address :");
-                show_spinner( self.spinner_msg(), freeze_table(ctx, alt_address)).await;
+                show_spinner(self.spinner_msg(), freeze_table(ctx, alt_address)).await;
             }
-            
+
             AltCommand::Deactivate => {
                 let alt_address: Pubkey = prompt_input_data("Enter ALT Address :");
-                show_spinner( self.spinner_msg(), deactivate_table(ctx, alt_address)).await;
+                show_spinner(self.spinner_msg(), deactivate_table(ctx, alt_address)).await;
             }
-            
+
             AltCommand::Close => {
                 let alt_address: Pubkey = prompt_input_data("Enter ALT Address :");
-                let recipient_input: String = prompt_input_data("Enter Recipient Address (leave empty for self) :");
+                let recipient_input: String =
+                    prompt_input_data("Enter Recipient Address (leave empty for self) :");
                 let recipient_address = if recipient_input.trim().is_empty() {
                     *ctx.pubkey()
-                } else {                                                                   
-                    recipient_input.parse()?                                                             
-                }; 
-                show_spinner( self.spinner_msg(), close_table(ctx, alt_address, recipient_address)).await;
+                } else {
+                    recipient_input.parse()?
+                };
+                show_spinner(
+                    self.spinner_msg(),
+                    close_table(ctx, alt_address, recipient_address),
+                )
+                .await;
             }
-            
+
             AltCommand::GoBack => {
                 return Ok(CommandFlow::NavigateTo(NavigationTarget::PreviousSection));
             }
@@ -100,13 +127,16 @@ impl Command for AltCommand {
 
 async fn create_table(ctx: &ScillaContext) -> anyhow::Result<()> {
     let recent_slot = ctx.rpc().get_slot().await?;
-    let (instruction, pubkey) = create_lookup_table(ctx.keypair().pubkey(), ctx.keypair().pubkey(), recent_slot);
+    let (instruction, pubkey) =
+        create_lookup_table(ctx.keypair().pubkey(), ctx.keypair().pubkey(), recent_slot);
 
     let signature = build_and_send_tx(ctx, &[instruction], &[ctx.keypair()]).await?;
 
     println!(
         "{}\n{}\n{}",
-        style("Address Lookup Table created successfully!").yellow().bold(),
+        style("Address Lookup Table created successfully!")
+            .yellow()
+            .bold(),
         style(format!("ALT Address: {pubkey}")).cyan(),
         style(format!("Signature: {signature}")).green()
     );
@@ -139,32 +169,38 @@ async fn get_lookup_table(ctx: &ScillaContext, pubkey: &Pubkey) -> anyhow::Resul
             Cell::new("Deactivation Slot"),
             Cell::new(format!("{}", alt_table_data.meta.deactivation_slot)),
         ])
-        .add_row(vec![Cell::new("Last Extended Slot"), Cell::new(format!("{}", alt_table_data.meta.last_extended_slot))]);
-    println!("{}\n{}", style("ALT METADATA").green().bold(), metadata_table);
+        .add_row(vec![
+            Cell::new("Last Extended Slot"),
+            Cell::new(format!("{}", alt_table_data.meta.last_extended_slot)),
+        ]);
+    println!(
+        "{}\n{}",
+        style("ALT METADATA").green().bold(),
+        metadata_table
+    );
 
-    if !alt_table_data.addresses.is_empty() {                                                            
+    if !alt_table_data.addresses.is_empty() {
         let mut address_table = Table::new();
-        address_table
-            .load_preset(UTF8_FULL)
-            .set_header(vec![
-                Cell::new("Index")
-                    .add_attribute(comfy_table::Attribute::Bold)
-                    .fg(comfy_table::Color::Cyan),
-                Cell::new("Address")
-                    .add_attribute(comfy_table::Attribute::Bold)
-                    .fg(comfy_table::Color::Cyan),
-            ]);
-            
+        address_table.load_preset(UTF8_FULL).set_header(vec![
+            Cell::new("Index")
+                .add_attribute(comfy_table::Attribute::Bold)
+                .fg(comfy_table::Color::Cyan),
+            Cell::new("Address")
+                .add_attribute(comfy_table::Attribute::Bold)
+                .fg(comfy_table::Color::Cyan),
+        ]);
+
         for (index, address) in alt_table_data.addresses.iter().enumerate() {
-            address_table.add_row(vec![
-                Cell::new(index),
-                Cell::new(address.to_string())  
-            ]);
+            address_table.add_row(vec![Cell::new(index), Cell::new(address.to_string())]);
         }
-        println!("{}\n{}", style("ADDRESS LOOKUP TABLE").green().bold(), address_table);
-    } else {                                                                               
-        println!("{}", style("No addresses stored in this table").yellow());                             
-    }                                                                                    
+        println!(
+            "{}\n{}",
+            style("ADDRESS LOOKUP TABLE").green().bold(),
+            address_table
+        );
+    } else {
+        println!("{}", style("No addresses stored in this table").yellow());
+    }
 
     Ok(())
 }
@@ -175,7 +211,9 @@ async fn freeze_table(ctx: &ScillaContext, alt_address: Pubkey) -> anyhow::Resul
 
     println!(
         "{}\n{}\n{}",
-        style("Address Lookup Table Frozen successfully!").yellow().bold(),
+        style("Address Lookup Table Frozen successfully!")
+            .yellow()
+            .bold(),
         style(format!("ALT Address: {alt_address}")).cyan(),
         style(format!("Signature: {signature}")).green()
     );
@@ -189,7 +227,9 @@ async fn deactivate_table(ctx: &ScillaContext, alt_address: Pubkey) -> anyhow::R
 
     println!(
         "{}\n{}\n{}",
-        style("Address Lookup Table Deactivated successfully!").yellow().bold(),
+        style("Address Lookup Table Deactivated successfully!")
+            .yellow()
+            .bold(),
         style(format!("ALT Address: {alt_address}")).cyan(),
         style(format!("Signature: {signature}")).green()
     );
@@ -197,10 +237,19 @@ async fn deactivate_table(ctx: &ScillaContext, alt_address: Pubkey) -> anyhow::R
     Ok(())
 }
 
-async fn extend_table(ctx: &ScillaContext, alt_address: Pubkey, address_strings: &str) -> anyhow::Result<()> {
+async fn extend_table(
+    ctx: &ScillaContext,
+    alt_address: Pubkey,
+    address_strings: &str,
+) -> anyhow::Result<()> {
     let address_pubkeys: Vec<Pubkey> = parse_addresses_string_to_pubkeys(address_strings)?;
     let address_len = address_pubkeys.len();
-    let instruction = extend_lookup_table(alt_address, *ctx.pubkey(), Some(*ctx.pubkey()), address_pubkeys);
+    let instruction = extend_lookup_table(
+        alt_address,
+        *ctx.pubkey(),
+        Some(*ctx.pubkey()),
+        address_pubkeys,
+    );
 
     let signature = build_and_send_tx(ctx, &[instruction], &[ctx.keypair()]).await?;
 
@@ -214,13 +263,19 @@ async fn extend_table(ctx: &ScillaContext, alt_address: Pubkey, address_strings:
     Ok(())
 }
 
-async fn close_table(ctx: &ScillaContext, alt_address: Pubkey, recipient_address: Pubkey) -> anyhow::Result<()> {
+async fn close_table(
+    ctx: &ScillaContext,
+    alt_address: Pubkey,
+    recipient_address: Pubkey,
+) -> anyhow::Result<()> {
     let instruction = close_lookup_table(alt_address, ctx.keypair().pubkey(), recipient_address);
     let signature = build_and_send_tx(ctx, &[instruction], &[ctx.keypair()]).await?;
 
     println!(
         "{}\n{}\n{}",
-        style("Address Lookup Table Closed successfully!").yellow().bold(),
+        style("Address Lookup Table Closed successfully!")
+            .yellow()
+            .bold(),
         style(format!("ALT Address: {alt_address}")).cyan(),
         style(format!("Signature: {signature}")).green()
     );

--- a/crates/scilla/src/commands/main_command.rs
+++ b/crates/scilla/src/commands/main_command.rs
@@ -3,9 +3,9 @@ use {
         commands::{Command, CommandFlow, navigation::NavigationSection},
         context::ScillaContext,
         prompt::{
-            prompt_account_section, prompt_cluster_section, prompt_config_section,
-            prompt_program_section, prompt_stake_section, prompt_transaction_section,
-            prompt_vote_section,
+            prompt_account_section, prompt_alt_section, prompt_cluster_section,
+            prompt_config_section, prompt_program_section, prompt_stake_section,
+            prompt_transaction_section, prompt_vote_section,
         },
     },
     anyhow::Ok,
@@ -19,6 +19,7 @@ pub enum MainCommand {
     Program,
     Vote,
     Transaction,
+    AddressLookupTable,
     ScillaConfig,
     Exit,
 }
@@ -32,6 +33,7 @@ impl fmt::Display for MainCommand {
             MainCommand::Program => "Program",
             MainCommand::Vote => "Vote",
             MainCommand::Transaction => "Transaction",
+            MainCommand::AddressLookupTable => "Address Lookup Table",
             MainCommand::ScillaConfig => "Scilla Config",
             MainCommand::Exit => "Exit",
         };
@@ -51,6 +53,7 @@ impl Command for MainCommand {
             MainCommand::Vote => prompt_vote_section()?.process_command(ctx).await?,
             MainCommand::Transaction => prompt_transaction_section()?.process_command(ctx).await?,
             MainCommand::Program => prompt_program_section()?.process_command(ctx).await?,
+            MainCommand::AddressLookupTable => prompt_alt_section()?.process_command(ctx).await?,
             MainCommand::ScillaConfig => prompt_config_section()?.process_command(ctx).await?,
             MainCommand::Exit => {
                 return Ok(CommandFlow::Exit);

--- a/crates/scilla/src/commands/mod.rs
+++ b/crates/scilla/src/commands/mod.rs
@@ -5,6 +5,7 @@ use {
 };
 
 pub mod account;
+pub mod alt;
 pub mod cluster;
 pub mod config;
 pub mod main_command;
@@ -13,7 +14,6 @@ pub mod program;
 pub mod stake;
 pub mod transaction;
 pub mod vote;
-pub mod alt;
 
 pub enum CommandFlow {
     Processed,

--- a/crates/scilla/src/commands/mod.rs
+++ b/crates/scilla/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod program;
 pub mod stake;
 pub mod transaction;
 pub mod vote;
+pub mod alt;
 
 pub enum CommandFlow {
     Processed,

--- a/crates/scilla/src/commands/navigation.rs
+++ b/crates/scilla/src/commands/navigation.rs
@@ -3,7 +3,9 @@ use {
         commands::{Command, CommandFlow, program::ProgramCommand},
         context::ScillaContext,
         prompt::{
-            prompt_account_section, prompt_alt_section, prompt_cluster_section, prompt_config_section, prompt_main_section, prompt_program_section, prompt_stake_section, prompt_transaction_section, prompt_vote_section
+            prompt_account_section, prompt_alt_section, prompt_cluster_section,
+            prompt_config_section, prompt_main_section, prompt_program_section,
+            prompt_stake_section, prompt_transaction_section, prompt_vote_section,
         },
     },
     std::fmt::{self, Display},

--- a/crates/scilla/src/commands/navigation.rs
+++ b/crates/scilla/src/commands/navigation.rs
@@ -3,9 +3,7 @@ use {
         commands::{Command, CommandFlow, program::ProgramCommand},
         context::ScillaContext,
         prompt::{
-            prompt_account_section, prompt_cluster_section, prompt_config_section,
-            prompt_main_section, prompt_program_section, prompt_stake_section,
-            prompt_transaction_section, prompt_vote_section,
+            prompt_account_section, prompt_alt_section, prompt_cluster_section, prompt_config_section, prompt_main_section, prompt_program_section, prompt_stake_section, prompt_transaction_section, prompt_vote_section
         },
     },
     std::fmt::{self, Display},
@@ -35,6 +33,7 @@ pub enum NavigationSection {
     Vote,
     Transaction,
     ScillaConfig,
+    AddressLookupTable,
     Exit,
 }
 
@@ -50,6 +49,7 @@ impl Display for NavigationSection {
             NavigationSection::Stake => "Stake",
             NavigationSection::Vote => "Vote",
             NavigationSection::Transaction => "Transaction",
+            NavigationSection::AddressLookupTable => "Address Lookup Table",
             NavigationSection::ScillaConfig => "Scilla Config",
             NavigationSection::Exit => "Exit",
         };
@@ -102,6 +102,11 @@ impl NavigationSection {
 
             NavigationSection::Transaction => {
                 let cmd = prompt_transaction_section()?;
+                cmd.process_command(ctx).await
+            }
+
+            NavigationSection::AddressLookupTable => {
+                let cmd = prompt_alt_section()?;
                 cmd.process_command(ctx).await
             }
 

--- a/crates/scilla/src/misc/helpers.rs
+++ b/crates/scilla/src/misc/helpers.rs
@@ -380,4 +380,35 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_parse_addresses_string_valid_input() {
+        let result = parse_addresses_string_to_pubkeys(
+            "11111111111111111111111111111111,TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_parse_addresses_string_with_whitespace() {
+        let result = parse_addresses_string_to_pubkeys(
+            "  11111111111111111111111111111111  ,  TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA  ",
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_parse_addresses_string_invalid_pubkey() {
+        let result = parse_addresses_string_to_pubkeys("invalid,pubkey");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_addresses_string_empty_input() {
+        let result = parse_addresses_string_to_pubkeys("");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
 }

--- a/crates/scilla/src/misc/helpers.rs
+++ b/crates/scilla/src/misc/helpers.rs
@@ -165,11 +165,8 @@ pub fn parse_addresses_string_to_pubkeys(input: &str) -> anyhow::Result<Vec<Pubk
         .split([',', '\n', ' '])
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
-        .map(|s| {
-            Pubkey::from_str(s)
-                .map_err(|_| anyhow!("Invalid pubkey: {}", s))
-        })
-        .collect::<Result<Vec<_>, _>>() 
+        .map(|s| Pubkey::from_str(s).map_err(|_| anyhow!("Invalid pubkey: {}", s)))
+        .collect::<Result<Vec<_>, _>>()
 }
 
 /// Generic helper to deserialize bincode data with consistent error

--- a/crates/scilla/src/misc/helpers.rs
+++ b/crates/scilla/src/misc/helpers.rs
@@ -153,13 +153,6 @@ pub async fn fetch_account_with_epoch(
     )
 }
 
-pub fn unpack_option_to_string<T: std::fmt::Display>(opt: &Option<T>) -> String {
-    match opt {
-        Some(val) => val.to_string(),
-        None => "None".to_string(),
-    }
-}
-
 pub fn parse_addresses_string_to_pubkeys(input: &str) -> anyhow::Result<Vec<Pubkey>> {
     input
         .split([',', '\n', ' '])

--- a/crates/scilla/src/misc/helpers.rs
+++ b/crates/scilla/src/misc/helpers.rs
@@ -153,6 +153,25 @@ pub async fn fetch_account_with_epoch(
     )
 }
 
+pub fn unpack_option_to_string<T: std::fmt::Display>(opt: &Option<T>) -> String {
+    match opt {
+        Some(val) => val.to_string(),
+        None => "None".to_string(),
+    }
+}
+
+pub fn parse_addresses_string_to_pubkeys(input: &str) -> anyhow::Result<Vec<Pubkey>> {
+    input
+        .split([',', '\n', ' '])
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            Pubkey::from_str(s)
+                .map_err(|_| anyhow!("Invalid pubkey: {}", s))
+        })
+        .collect::<Result<Vec<_>, _>>() 
+}
+
 /// Generic helper to deserialize bincode data with consistent error
 /// context
 pub fn bincode_deserialize<T>(data: &[u8], ctx: &str) -> anyhow::Result<T>

--- a/crates/scilla/src/prompt.rs
+++ b/crates/scilla/src/prompt.rs
@@ -1,7 +1,17 @@
 use {
     crate::{
         commands::{
-            Command, account::AccountCommand, alt::AltCommand, cluster::ClusterCommand, config::ConfigCommand, main_command::MainCommand, navigation::NavigationTarget, program::{ProgramCommand, ProgramShared}, stake::StakeCommand, transaction::TransactionCommand, vote::VoteCommand
+            Command,
+            account::AccountCommand,
+            alt::AltCommand,
+            cluster::ClusterCommand,
+            config::ConfigCommand,
+            main_command::MainCommand,
+            navigation::NavigationTarget,
+            program::{ProgramCommand, ProgramShared},
+            stake::StakeCommand,
+            transaction::TransactionCommand,
+            vote::VoteCommand,
         },
         constants::{DEVNET_RPC, MAINNET_RPC, TESTNET_RPC},
         context::ScillaContext,

--- a/crates/scilla/src/prompt.rs
+++ b/crates/scilla/src/prompt.rs
@@ -1,16 +1,7 @@
 use {
     crate::{
         commands::{
-            Command,
-            account::AccountCommand,
-            cluster::ClusterCommand,
-            config::ConfigCommand,
-            main_command::MainCommand,
-            navigation::NavigationTarget,
-            program::{ProgramCommand, ProgramShared},
-            stake::StakeCommand,
-            transaction::TransactionCommand,
-            vote::VoteCommand,
+            Command, account::AccountCommand, alt::AltCommand, cluster::ClusterCommand, config::ConfigCommand, main_command::MainCommand, navigation::NavigationTarget, program::{ProgramCommand, ProgramShared}, stake::StakeCommand, transaction::TransactionCommand, vote::VoteCommand
         },
         constants::{DEVNET_RPC, MAINNET_RPC, TESTNET_RPC},
         context::ScillaContext,
@@ -31,6 +22,7 @@ pub fn prompt_main_section() -> anyhow::Result<impl Command> {
             MainCommand::Program,
             MainCommand::Vote,
             MainCommand::Transaction,
+            MainCommand::AddressLookupTable,
             MainCommand::ScillaConfig,
             MainCommand::Exit,
         ],
@@ -174,6 +166,24 @@ pub fn prompt_config_section() -> anyhow::Result<ConfigCommand> {
             ConfigCommand::Show,
             ConfigCommand::Edit,
             ConfigCommand::GoBack,
+        ],
+    )
+    .prompt()?;
+
+    Ok(choice)
+}
+
+pub fn prompt_alt_section() -> anyhow::Result<AltCommand> {
+    let choice = Select::new(
+        "ALT Command:",
+        vec![
+            AltCommand::Get,
+            AltCommand::Create,
+            AltCommand::Extend,
+            AltCommand::Deactivate,
+            AltCommand::Freeze,
+            AltCommand::Close,
+            AltCommand::GoBack,
         ],
     )
     .prompt()?;


### PR DESCRIPTION
## Summary                                                       
  - Add Address Lookup Table command group with full lifecycle management  
  - Commands: Create, Get, Extend, Freeze, Deactivate, Close               
  - Add parse_addresses_string_to_pubkeys helper with tests 

### Related Issue
Resolves #116 