### PR TITLE
Add recent priotization fee command

### DIFF
--- a/crates/scilla/src/commands/cluster.rs
+++ b/crates/scilla/src/commands/cluster.rs
@@ -388,8 +388,8 @@ async fn fetch_recent_prioritization_fee(ctx: &ScillaContext) -> anyhow::Result<
     let mut fee_values: Vec<u64> = fees.iter().map(|f| f.prioritization_fee).collect();
     fee_values.sort();
 
-    let min_fee = fee_values.iter().min().unwrap_or(&0);
-    let max_fee = fee_values.iter().max().unwrap_or(&0);
+    let min_fee = fee_values.first().unwrap_or(&0);
+    let max_fee = fee_values.last().unwrap_or(&0);
     let avg_fee = fee_values.iter().sum::<u64>() / fee_values.len() as u64;
     let median_fee = fee_values[fee_values.len() / 2];
 

--- a/crates/scilla/src/commands/cluster.rs
+++ b/crates/scilla/src/commands/cluster.rs
@@ -4,7 +4,7 @@ use {
             Command, CommandFlow,
             navigation::{NavigationSection, NavigationTarget},
         },
-        constants::{LAMPORTS_PER_SOL, SLOTS_TAKEN},
+        constants::LAMPORTS_PER_SOL,
         context::ScillaContext,
         ui::show_spinner,
     },
@@ -425,11 +425,18 @@ async fn fetch_recent_prioritization_fee(ctx: &ScillaContext) -> anyhow::Result<
         Cell::new("Fee (micro-lamports/CU)").add_attribute(comfy_table::Attribute::Bold),
     ]);
 
-    for fee in recent_fees.iter().take(SLOTS_TAKEN) {
+    const SLOTS_SHOWN: usize = 10;
+
+    for fee in recent_fees.iter().take(SLOTS_SHOWN) {
         detail_table.add_row(vec![Cell::new(fee.slot), Cell::new(fee.prioritization_fee)]);
     }
 
-    println!("\n{}", style("RECENT SLOTS").green().bold());
+    println!(
+        "\n{}",
+        style(format!("RECENT SLOTS (last {})", SLOTS_SHOWN))
+            .green()
+            .bold()
+    );
     println!("{detail_table}");
 
     Ok(())

--- a/crates/scilla/src/constants.rs
+++ b/crates/scilla/src/constants.rs
@@ -17,3 +17,5 @@ pub const DEFAULT_EPOCH_LIMIT: usize = 10;
 pub const STAKE_HISTORY_SYSVAR_ADDR: &str = "SysvarStakeHistory1111111111111111111111111";
 
 pub const MEMO_PROGRAM_ID: &str = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+
+pub const SLOTS_TAKEN: usize = 10;

--- a/crates/scilla/src/constants.rs
+++ b/crates/scilla/src/constants.rs
@@ -17,5 +17,3 @@ pub const DEFAULT_EPOCH_LIMIT: usize = 10;
 pub const STAKE_HISTORY_SYSVAR_ADDR: &str = "SysvarStakeHistory1111111111111111111111111";
 
 pub const MEMO_PROGRAM_ID: &str = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
-
-pub const SLOTS_TAKEN: usize = 10;

--- a/crates/scilla/src/prompt.rs
+++ b/crates/scilla/src/prompt.rs
@@ -74,6 +74,7 @@ pub fn prompt_cluster_section() -> anyhow::Result<ClusterCommand> {
             ClusterCommand::ClusterVersion,
             ClusterCommand::SupplyInfo,
             ClusterCommand::Inflation,
+            ClusterCommand::RecentPriorityFees,
             ClusterCommand::GoBack,
         ],
     )


### PR DESCRIPTION
 ## Summary                                                                                            
  - Adds `RecentPriorityFees` command to the Cluster command group                                      
  - Displays priority fee statistics (min, max, average, median)                                        
  - Shows recent slots with their priority fees                                                         
  - Uses `getRecentPrioritizationFees` RPC method                                          
                                                                                                        
  Closes #118