### PR TITLE
Add decode-transaction command

### DIFF
--- a/crates/scilla/src/prompt.rs
+++ b/crates/scilla/src/prompt.rs
@@ -163,6 +163,7 @@ pub fn prompt_transaction_section() -> anyhow::Result<TransactionCommand> {
             TransactionCommand::FetchTransaction,
             TransactionCommand::SendTransaction,
             TransactionCommand::SimulateTransaction,
+            TransactionCommand::DecodeTransaction,
             TransactionCommand::GoBack,
         ],
     )


### PR DESCRIPTION
## Summary                                                                              
  - Adds `DecodeTransaction` command to the Transaction command group                     
  - Decodes base58/base64 encoded transactions                
  - Displays signatures, message details, account keys, and instructions                  
  - Supports both Legacy and V0 (versioned) transaction formats                           
  - V0 transactions show address table lookups                                            
                                                                                          
  Closes #120  